### PR TITLE
add test case for no branch protection

### DIFF
--- a/github_standards/standards.py
+++ b/github_standards/standards.py
@@ -58,7 +58,7 @@ def check_and_apply_standard_properties_to_branch(repo, branch: Branch, do_actua
     branch_protection: Optional[BranchProtection] = None
     try:
         branch_protection = branch.get_protection()
-    except GithubException as e:
+    except GithubException:
         # GH returns a 404 when Branch Protection is not yet enabled for the branch in question
         print(f'    Branch {branch} is not protected in {repo.name}')
 

--- a/github_standards/test/test_standards.py
+++ b/github_standards/test/test_standards.py
@@ -191,7 +191,7 @@ class TestStandardProps(unittest.TestCase):
 
         self.assertEqual(result, "")
         branch.edit_protection.assert_called_once_with(allow_deletions=False,
-                                                       allow_force_pushes=False)  # this is the only change
+                                                       allow_force_pushes=False)
 
     def test_props_out_of_spec_branch_makes_a_change(self):
         repo = self.create_mock_repo()

--- a/github_standards/test/test_standards.py
+++ b/github_standards/test/test_standards.py
@@ -171,7 +171,6 @@ class TestStandardProps(unittest.TestCase):
         # noinspection PyTypeChecker
         branch = Branch(requester='', headers='', attributes={}, completed='')
         branch.get_protection = MagicMock()
-        # noinspection PyTypeChecker
         ghe = GithubException(status=404, data=None)
         branch.get_protection.side_effect = ghe
 


### PR DESCRIPTION
Here's stab at a test case for that GH behavior when no branch protection is enabled.